### PR TITLE
Add handling for escaped backslashes in module names.

### DIFF
--- a/mine.js
+++ b/mine.js
@@ -63,7 +63,19 @@ function mine(js) {
     if (char === quote) {
       return $close;
     }
+    if (char === "\\") {
+      return $nameEscape;
+    }
     name += char;
+    return $name;
+  }
+
+  function $nameEscape(char) {
+    if (char === "\\") {
+      name += char;
+    } else {
+      name += JSON.parse('"\\' + char + '"');
+    }
     return $name;
   }
 

--- a/test/files/windows_relative.js
+++ b/test/files/windows_relative.js
@@ -1,0 +1,1 @@
+var a = require('./a\\b\\c');

--- a/test/windows_relative.js
+++ b/test/windows_relative.js
@@ -1,0 +1,11 @@
+var test = require('tap').test;
+var mine = require('../');
+var fs = require('fs');
+var src = fs.readFileSync(__dirname + '/files/windows_relative.js');
+
+test('windows_relative', function(t) {
+  t.plan(1);
+  t.deepEqual(mine(src), [
+    {name: './a\\b\\c', offset: 17}
+  ]);
+});


### PR DESCRIPTION
This can occur when requiring modules on Windows with relative paths (typically in Browserify or other programmatically generated require transforms). Prior to this change, mine would output strings that
were double-escaped (2 backslashes for each one found in the string).

This change also adds handling for other backslash-escaped characters in module names, although I think these are mostly non-sensical, it should preserve them.

Fixes substack/node-browserify#639
