### PR TITLE
Ignore tokens in RegExp

### DIFF
--- a/mine.js
+++ b/mine.js
@@ -108,7 +108,9 @@ function mine(js) {
   function $slash(char) {
     if (char === "/") return $lineComment;
     if (char === "*") return $multilineComment;
-    return $start(char);
+    // regexp
+    quote = "/";
+    return $string(char);
   }
 
   function $lineComment(char) {
@@ -127,8 +129,16 @@ function mine(js) {
     return $multilineComment;
   }
 
+  var i = 0;
   state = $start;
-  for (var i = 0, l = js.length; i < l; i++) {
+
+  // check shebang
+  if (js.slice(0, 2) === '#!') {
+    state = $lineComment;
+    i = 2;
+  }
+
+  for (var l = js.length; i < l; i++) {
     state = state(js[i]);
   }
   return names;

--- a/mine.js
+++ b/mine.js
@@ -11,9 +11,11 @@ function mine(js) {
   var quote;
   var name;
   var start;
+  var previous;
 
   var isIdent = /[a-z0-9_.$]/i;
   var isWhitespace = /[ \r\n\t]/;
+  var isBeforeRegExp = /[(,=:[!&|?{};]/;
 
   function $start(char) {
     if (char === "/") {
@@ -108,9 +110,11 @@ function mine(js) {
   function $slash(char) {
     if (char === "/") return $lineComment;
     if (char === "*") return $multilineComment;
-    // regexp
-    quote = "/";
-    return $string(char);
+    if (!previous || isBeforeRegExp.test(previous)) {
+      quote = "/";
+      return $string(char);
+    }
+    return $start(char);
   }
 
   function $lineComment(char) {
@@ -140,6 +144,7 @@ function mine(js) {
 
   for (var l = js.length; i < l; i++) {
     state = state(js[i]);
+    if (!isWhitespace.test(js[i]) && js[i] !== '/') previous = js[i];
   }
   return names;
 }

--- a/test/division.js
+++ b/test/division.js
@@ -1,0 +1,13 @@
+var test = require('tap').test;
+var mine = require('../');
+var fs = require('fs');
+var src = fs.readFileSync(__dirname + '/files/division.js');
+
+test('division', function (t) {
+  t.plan(1);
+  t.deepEqual(mine(src), [
+    {name: 'a', offset: 29},
+    {name: 'b', offset: 66},
+    {name: 'c', offset: 112}
+  ]);
+});

--- a/test/files/division.js
+++ b/test/files/division.js
@@ -1,0 +1,11 @@
+var num1 = 10 / 2;
+
+require("a");
+
+var num2 = num1 / 3;
+
+require("b");
+
+var num3 = (num1 + num2) / 4;
+
+require("c");

--- a/test/files/regexp.js
+++ b/test/files/regexp.js
@@ -1,0 +1,3 @@
+var pattern = /require("a");'/ig;
+
+require('b');

--- a/test/files/regexp.js
+++ b/test/files/regexp.js
@@ -1,3 +1,7 @@
-var pattern = /require("a");'/ig;
+var pattern = /require("a")/ig;
 
 require('b');
+
+/"/;
+
+require('c');

--- a/test/regexp.js
+++ b/test/regexp.js
@@ -1,0 +1,11 @@
+var test = require('tap').test;
+var mine = require('../');
+var fs = require('fs');
+var src = fs.readFileSync(__dirname + '/files/regexp.js');
+
+test('regexp', function (t) {
+    t.plan(1);
+    t.deepEqual(mine(src), [
+      {name: 'b', offset: 44}
+    ]);
+});

--- a/test/regexp.js
+++ b/test/regexp.js
@@ -6,6 +6,7 @@ var src = fs.readFileSync(__dirname + '/files/regexp.js');
 test('regexp', function (t) {
     t.plan(1);
     t.deepEqual(mine(src), [
-      {name: 'b', offset: 44}
+      {name: 'b', offset: 42},
+      {name: 'c', offset: 63}
     ]);
 });


### PR DESCRIPTION
Some tokens in RegExp literal caused the following problems:
- Unclosed quotes mess up the state so that following `require()` calls are not properly detected. e.g. `var pattern = /"/; require("a");` then `a` is not detected.
- `require()` calls in RegExp literal are wrongly detected. e.g. `var pattern = /require("a")/;` then `a` is detected.

To fix those issues, this patch treats RegExp literals as strings with slash as quote. To keep supporting shebang that inevitably contains slashes, now it is handled before the parsing starts.
