### PR TITLE
Start a new identifier after any whitespace

### DIFF
--- a/mine.js
+++ b/mine.js
@@ -35,15 +35,16 @@ function mine(js) {
       ident += char;
       return $ident;
     }
+    return $identEnd(char);
+  }
+
+  function $identEnd(char) {
     if (char === "(" && ident === "require") {
       ident = undefined;
       return $call;
-    } else {
-      if (isWhitespace.test(char)){
-        if (ident !== 'yield' && ident !== 'return'){
-          return $ident;
-        }
-      }
+    }
+    if (isWhitespace.test(char)) {
+        return $identEnd;
     }
     return $start(char);
   }

--- a/test/files/property.js
+++ b/test/files/property.js
@@ -1,0 +1,2 @@
+require("abc").blah
+require("def")

--- a/test/property.js
+++ b/test/property.js
@@ -1,0 +1,11 @@
+var test = require('tap').test;
+var mine = require('../');
+var fs = require('fs');
+var src = fs.readFileSync(__dirname + '/files/property.js');
+
+test('property', function (t) {
+    t.deepEqual(mine(src), [
+      {name: 'abc', offset: 9},
+      {name: 'def', offset: 29} ]);
+    t.end();
+});

--- a/test/word.js
+++ b/test/word.js
@@ -1,0 +1,9 @@
+var test = require('tap').test;
+var mine = require('../');
+var fs = require('fs');
+var src = fs.readFileSync(__dirname + '/files/word.js');
+
+test('word', function (t) {
+    t.deepEqual(mine(src), []);
+    t.end();
+});


### PR DESCRIPTION
This was driven by the discovery that this require was not detected:

https://github.com/isaacs/node-tap/blob/master/lib/tap-harness.js#L13

I managed to distill this into the attached testcase, and adjusted the FSM to make it pass.
Starting a new identifier after any whitespace means the yield/return case is now generalised, and safe to remove.

This is part of a chain of fixes I'm doing to add testling tests to a module, a version bump would be appreciated so I can ask @substack to update this through module-deps, browserify & testling :)
