### PR TITLE
Whitespace and regex handling

### DIFF
--- a/mine.js
+++ b/mine.js
@@ -5,15 +5,25 @@
 module.exports = mine;
 function mine(js) {
   js = "" + js;
+
+  var l = js.length;
+  var i;
   var names = [];
-  var state = 0;
+  var state;
   var ident;
   var quote;
   var name;
   var start;
+  var regexBacktrack;
 
   var isIdent = /[a-z0-9_.$]/i;
   var isWhitespace = /[ \r\n\t]/;
+  function isNewLine(char) {
+    return char === "\r" || char === "\n";
+  }
+  function isEOF() {
+    return i == (l - 1);
+  }
 
   function $start(char) {
     if (char === "/") {
@@ -22,6 +32,9 @@ function mine(js) {
     if (char === "'" || char === '"') {
       quote = char;
       return $string;
+    }
+    if (char === "#") {
+      return $hash;
     }
     if (isIdent.test(char)) {
       ident = char;
@@ -43,9 +56,11 @@ function mine(js) {
       ident = undefined;
       return $call;
     }
+
     if (isWhitespace.test(char)) {
         return $identEnd;
     }
+
     return $start(char);
   }
 
@@ -109,11 +124,12 @@ function mine(js) {
   function $slash(char) {
     if (char === "/") return $lineComment;
     if (char === "*") return $multilineComment;
-    return $start(char);
+    regexBacktrack = i;
+    return $regex(char);
   }
 
   function $lineComment(char) {
-    if (char === "\r" || char === "\n") return $start;
+    if (isNewLine(char)) return $start;
     return $lineComment;
   }
 
@@ -128,8 +144,38 @@ function mine(js) {
     return $multilineComment;
   }
 
+  function $regex(char) {
+    if (char === "\\") {
+      return $regexEscape;
+    }
+    if (char === "/") {
+      regexBacktrack = null;
+      return $start;
+    }
+    if (isNewLine(char) || isEOF()) {
+      // This isn't a regex, must have been division!
+      // backtrack and pretend we knew that.
+      i = regexBacktrack - 1;
+      return $start;
+    }
+
+    return $regex;
+  }
+
+  function $regexEscape() {
+    return $regex;
+  }
+
+  function $hash(char) {
+    if (char === '!') {
+      // technically shebang, but equivalent for JS
+      return $lineComment
+    }
+    return $start;
+  }
+
   state = $start;
-  for (var i = 0, l = js.length; i < l; i++) {
+  for (i = 0; i < l; i++) {
     state = state(js[i]);
   }
   return names;

--- a/mine.js
+++ b/mine.js
@@ -35,15 +35,16 @@ function mine(js) {
       ident += char;
       return $ident;
     }
+    return $identEnd(char);
+  }
+
+  function $identEnd(char) {
     if (char === "(" && ident === "require") {
       ident = undefined;
       return $call;
-    } else {
-      if (isWhitespace.test(char)){
-        if (ident !== 'yield' && ident !== 'return'){
-          return $ident;
-        }
-      }
+    }
+    if (isWhitespace.test(char)) {
+        return $identEnd;
     }
     return $start(char);
   }

--- a/test/files/property.js
+++ b/test/files/property.js
@@ -1,0 +1,2 @@
+require("abc").blah
+require("def")

--- a/test/files/regex.js
+++ b/test/files/regex.js
@@ -1,0 +1,18 @@
+/"/;
+/\//
+require('a')
+
+4 / 1
+require('b')
+
+var a = 1
+a /= 1
+require('c')
+
+var tricky = require('d') /require('e')
+
+// Currently no 'easy' way to get 'g' - but this is probably rare.
+var hard = require('f') / require('g') / require('h')
+
+// EOF before 'regex' ends
+a / require('i')

--- a/test/property.js
+++ b/test/property.js
@@ -1,0 +1,11 @@
+var test = require('tap').test;
+var mine = require('../');
+var fs = require('fs');
+var src = fs.readFileSync(__dirname + '/files/property.js');
+
+test('property', function (t) {
+    t.deepEqual(mine(src), [
+      {name: 'abc', offset: 9},
+      {name: 'def', offset: 29} ]);
+    t.end();
+});

--- a/test/regex.js
+++ b/test/regex.js
@@ -1,0 +1,20 @@
+var test = require('tap').test;
+var mine = require('../');
+var fs = require('fs');
+var src = fs.readFileSync(__dirname + '/files/regex.js');
+
+test('regex or division', function (t) {
+    t.deepEqual(mine(src), [
+      {name: 'a', offset: 19},
+      {name: 'b', offset: 39},
+      {name: 'c', offset: 70},
+      {name: 'd', offset: 97},
+      {name: 'e', offset: 111},
+      {name: 'f', offset: 203},
+      // currently not able to find a require()
+      // between two / tokens on the same line
+      //{name: 'g', offset: 218},
+      {name: 'h', offset: 233},
+      {name: 'i', offset: 278}, ]);
+    t.end();
+});

--- a/test/word.js
+++ b/test/word.js
@@ -1,0 +1,9 @@
+var test = require('tap').test;
+var mine = require('../');
+var fs = require('fs');
+var src = fs.readFileSync(__dirname + '/files/word.js');
+
+test('word', function (t) {
+    t.deepEqual(mine(src), []);
+    t.end();
+});


### PR DESCRIPTION
This PR supersedes #5, as I needed those changes to get the tests passing in this branch.

This should also resolve #2 and #4.

I had to step outside the current parsing algorithm slightly, in order to handle the regex vs division case.

Rather than implement the full state machine to tell whether in a unary or binary expression context, I use the heuristic that a regular expression cannot contain a newline character. This means that if a newline is encountered before the closing `/`, and we know we have valid javascript, we can safely assume that it must have been division and backtrack, continuing with this new knowledge.

As noted in the testcase, this does still leave the case of

``` javascript
var a = 1 / require('a') / 2;
```

However this is no worse than before the PR, and I do manage to cover a number of other common cases (#4 has some examples).
